### PR TITLE
Fix inverted return value in `validateFile`

### DIFF
--- a/src/e57validate.cpp
+++ b/src/e57validate.cpp
@@ -2802,7 +2802,7 @@ bool validateFile(E57ValidatorOptions options, ustring fname)
             if (options.messagesAllowed[i] > 0)
                 messageCount += validator.messageCount(i);
         }
-        return(messageCount > 0);
+        return(messageCount == 0);
     } catch(E57Exception& ex) {
         ex.report(__FILE__, __LINE__, __FUNCTION__);
     } catch (std::exception& ex) {


### PR DESCRIPTION
**I assume this patch to fix an actual bug (and not just unusual, but intended behavior), but be aware this is a breaking change, as the program's return values are altered.**

`validateFile()` currently returned whether there had been any errors. So the result was `true` if there were error messages and false when there were no error messages (or the validation was aborted by an exception).
The code in `main()` that was running the validation interpreted the results differently: `bool gotError = !validateFile(...);`

This **changes** the behavior of `validateFile()` such that it returns `true` on success and `false` on validation error (ie. `messageCount != 0`) or in case of an exception. This inverts the program's return code to be `0` for successful validation and `-1` in all other cases.